### PR TITLE
Updated how the repo name is extracted from the image name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,26 @@
+# Builder Image
+FROM golang:1.10.3-alpine AS BUILDER
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN apk update && \
+    apk upgrade && \
+    apk add git && \
+    wget -O - https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+RUN dep ensure -vendor-only
+RUN CGO_ENABLED=0 go build
+
+# Docker Image
 FROM python:3-alpine
+
+WORKDIR /app
 ENV AWS_REGION eu-west-2
+
 RUN apk add --no-cache ca-certificates 
-ADD k8ecr /
-ADD autodeploy.py /
 RUN pip install requests 
-CMD ./autodeploy.py
+COPY --from=BUILDER /go/src/app/k8ecr /app/k8ecr
+COPY autodeploy.py /app/
+
+ENTRYPOINT /app/autodeploy.py

--- a/deploy.go
+++ b/deploy.go
@@ -147,7 +147,7 @@ type Image struct {
 }
 
 func newImage(url string) Image {
-	p1 := strings.Split(url, "/")
+	p1 := strings.SplitN(url, "/", 2)
 	p2 := strings.Split(p1[1], ":")
 	version := "latest"
 	if len(p2) == 2 {


### PR DESCRIPTION
Docker allows an image name to contain multiple slashes i.e `hostname/component1/component2:tag`

The current implementation was splitting the image name into too many slices, 3 in this example instead of just 2. And when trying to split the second slice (in this case `component1`) on a colon to extract the tag it was returning nothing.

`strings.SplitN(url, "/", 2)` will only split on the first slash so that:
```
p1[0] = hostname
p1[1] = component1/component2:tag
```


